### PR TITLE
Philipp fix version check (#1011)

### DIFF
--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -123,12 +123,13 @@ else:
     from lightly import transforms
     from lightly import utils
     
-    from lightly.api.version_checking import do_version_check
-
     if os.getenv('LIGHTLY_DID_VERSION_CHECK', 'False') == 'False':
         os.environ['LIGHTLY_DID_VERSION_CHECK'] = 'True'
-
-        try:
-            do_version_check(current_version=__version__)
-        except Exception as e:
-            pass
+        from multiprocessing import current_process
+        if current_process().name == 'MainProcess':
+            from lightly.api.version_checking import is_latest_version, LightlyAPITimeoutException
+            from lightly.openapi_generated.swagger_client.rest import ApiException
+            try:
+                is_latest_version(current_version=__version__)
+            except (ValueError, ApiException, LightlyAPITimeoutException):
+                pass

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -20,10 +20,8 @@ from lightly.api.api_workflow_selection import _SelectionMixin
 from lightly.api.api_workflow_upload_dataset import _UploadDatasetMixin
 from lightly.api.api_workflow_upload_embeddings import _UploadEmbeddingsMixin
 from lightly.api.api_workflow_upload_metadata import _UploadCustomMetadataMixin
-from lightly.api.bitmask import BitMask
-from lightly.api.utils import DatasourceType, get_signed_url_destination, getenv
-from lightly.api.version_checking import get_minimum_compatible_version, \
-    version_compare
+from lightly.api.utils import DatasourceType, get_signed_url_destination, get_api_client_configuration
+from lightly.api.version_checking import is_compatible_version
 from lightly.openapi_generated.swagger_client.api.collaboration_api import CollaborationApi
 from lightly.openapi_generated.swagger_client import ScoresApi, QuotaApi, MetaDataConfigurationsApi, PredictionsApi
 from lightly.openapi_generated.swagger_client.api.datasets_api import \
@@ -41,8 +39,6 @@ from lightly.openapi_generated.swagger_client.api.samplings_api import \
     SamplingsApi
 from lightly.openapi_generated.swagger_client.api.tags_api import TagsApi
 from lightly.openapi_generated.swagger_client.api_client import ApiClient
-from lightly.openapi_generated.swagger_client.configuration import \
-    Configuration
 from lightly.openapi_generated.swagger_client.models.dataset_data import \
     DatasetData
 from lightly.utils.reordering import sort_items_by_keys
@@ -88,7 +84,13 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         embedding_id: Optional[str] = None
     ):
 
-        self.check_version_compatibility()
+        if not is_compatible_version(__version__):
+            warnings.warn(
+                UserWarning((f"Incompatible version of lightly pip package. "
+                             f"Please upgrade to the latest version "
+                             f"to be able to access the api.")
+                )
+            )
 
         configuration = get_api_client_configuration(token=token)
         self.api_client = ApiClient(configuration=configuration)
@@ -116,13 +118,6 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         self._metadata_configurations_api = \
             MetaDataConfigurationsApi(api_client=self.api_client)
         self._predictions_api = PredictionsApi(api_client=self.api_client)
-
-    def check_version_compatibility(self):
-        minimum_version = get_minimum_compatible_version()
-        if version_compare(__version__, minimum_version) < 0:
-            raise ValueError(f"Incompatible Version of lightly pip package. "
-                             f"Please upgrade to at least version {minimum_version} "
-                             f"to be able to access the api and webapp")
 
     @property
     def dataset_id(self) -> str:
@@ -293,26 +288,3 @@ def set_api_client_request_timeout(
         return request_fn(*args, **kwargs)
 
     client.rest_client.request = new_request_fn
-
-
-def get_api_client_configuration(
-    token: Optional[str] = None,
-    raise_if_no_token_specified: bool = True,
-) -> Configuration:
-
-    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai")
-    ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
-
-    if token is None:
-        token = getenv("LIGHTLY_TOKEN", None)
-    if token is None and raise_if_no_token_specified:
-        raise ValueError(
-            "Either provide a 'token' argument or export a LIGHTLY_TOKEN environment variable"
-        )
-
-    configuration = Configuration()
-    configuration.api_key = {"token": token}
-    configuration.ssl_ca_cert = ssl_ca_cert
-    configuration.host = host
-
-    return configuration

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -8,15 +8,14 @@ import os
 import time
 import random
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
-import numpy as np
-from PIL import Image, ImageFilter
 # the following two lines are needed because
 # PIL misidentifies certain jpeg images as MPOs
 from PIL import JpegImagePlugin
-
 JpegImagePlugin._getmp = lambda: None
+
+from lightly.openapi_generated.swagger_client.configuration import Configuration
 
 MAXIMUM_FILENAME_LENGTH = 255
 RETRY_MAX_BACKOFF = 32
@@ -192,3 +191,26 @@ def get_signed_url_destination(signed_url: str = '') -> DatasourceType:
         return DatasourceType.AZURE
     # default to local as it must be some special setup
     return DatasourceType.LOCAL
+
+
+def get_api_client_configuration(
+    token: Optional[str] = None,
+    raise_if_no_token_specified: bool = True,
+) -> Configuration:
+
+    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai")
+    ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
+
+    if token is None:
+        token = getenv("LIGHTLY_TOKEN", None)
+    if token is None and raise_if_no_token_specified:
+        raise ValueError(
+            "Either provide a 'token' argument or export a LIGHTLY_TOKEN environment variable"
+        )
+
+    configuration = Configuration()
+    configuration.api_key = {"token": token}
+    configuration.ssl_ca_cert = ssl_ca_cert
+    configuration.host = host
+
+    return configuration

--- a/tests/api/test_version_checking.py
+++ b/tests/api/test_version_checking.py
@@ -5,7 +5,7 @@ import unittest
 import lightly
 from lightly.api.version_checking import get_latest_version, \
     get_minimum_compatible_version, pretty_print_latest_version, \
-    LightlyAPITimeoutException, do_version_check
+    LightlyAPITimeoutException, is_latest_version, is_compatible_version
 
 from tests.api_workflow.mocked_api_workflow_client import MockedVersioningApi
 
@@ -20,6 +20,18 @@ class TestVersionChecking(unittest.TestCase):
 
     def test_get_minimum_compatible_version(self):
         get_minimum_compatible_version()
+
+    def test_is_latest_version(self) -> None:
+        assert is_latest_version("1.2.8")
+        assert not is_latest_version("1.2.7")
+        assert not is_latest_version("1.1.8")
+        assert not is_latest_version("0.2.8")
+
+    def test_is_compatible_version(self) -> None:
+        assert is_compatible_version("1.2.1")
+        assert not is_compatible_version("1.2.0")
+        assert not is_compatible_version("1.1.9")
+        assert not is_compatible_version("0.2.1")
 
     def test_pretty_print(self):
         pretty_print_latest_version(current_version="curr", latest_version="1.1.1")
@@ -48,7 +60,7 @@ class TestVersionChecking(unittest.TestCase):
             start_time = time.time()
 
             with self.assertRaises(LightlyAPITimeoutException):
-                do_version_check(lightly.__version__)
+                is_latest_version(lightly.__version__)
 
             duration = time.time() - start_time
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -989,10 +989,10 @@ class MockedComputeWorkerApi(DockerApi):
 
 class MockedVersioningApi(VersioningApi):
     def get_latest_pip_version(self, **kwargs):
-        return "1.0.8"
+        return "1.2.8"
 
     def get_minimum_compatible_pip_version(self, **kwargs):
-        return "1.0.0"
+        return "1.2.1"
 
 
 class MockedQuotaApi(QuotaApi):

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -27,7 +27,7 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
 
     def test_error_if_version_is_incompatible(self):
         lightly.api.api_workflow_client.__version__ = "0.0.0"
-        with self.assertRaises(ValueError):
+        with self.assertWarns(UserWarning):
             MockedApiWorkflowClient(token="token_xyz")
         lightly.api.api_workflow_client.__version__ = lightly.__version__
 


### PR DESCRIPTION
The version check was broken because of circular imports that were swallowed by a try-catch. I resolved the circular import by moving the relevant function to lightly.api.utils.